### PR TITLE
External styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,9 @@ ContentSlider is currently a private package, published under the `@crossfield` 
 ```
 # Install package and dependency
 $ NPM_TOKEN=xxxx-xxxx-xxxxx-xx npm install @crossfield/content-slider
-
-# Install postcssJS and autoprefixer in order to prefix inlined styles.
-$ npm install json-loader
-
-# These require you to add a couple things to your webpack configs:
-## at depth 0 of config object
-node: {
-  fs: 'empty'
-},
-
-## inside modules.loaders or modules.rules
-{
-  test: /\.json$/,
-  loader: 'json-loader'
-}
 ```
 
-There's a css file that contains some helpful styles for working w/iframes, images, and fix for mobile browsers that don't contain flexbox support w/o prefixing. There are additional hints in this css file for troubleshooting IE issues around flexbox and the height of slider content (TLDR - you may need to add height overrides for IE).
+There's a CSS file with all the base styles and some helpful styles for working w/iframes, images, and fix for mobile browsers that don't contain flexbox support w/o prefixing. There are additional hints in this CSS file for troubleshooting IE issues around flexbox and the height of slider content (TLDR - you may need to add height overrides for IE).
 
 
 ## Props
@@ -51,23 +36,6 @@ There's a css file that contains some helpful styles for working w/iframes, imag
 | maxAspectRatio | number | Slider content height relative to the width. Default value works for most media-only content, however you'll likely want to adjust the ratio for mixed content (or anything that would be constrained by this property on mobile). | 0.5625 (16:9 aspect ratio) |
 | frameIndexOverride | number | Index of the frame to show. You can pass this to initiate the slider on a frame index other than 0, or use the prop in conjunction with `clickHandlers` props or other external controls to drive the slider manually. | none |
 | clickHandlers | object::shape { onArrowLeft, onArrowRight } | Pass an object with callbacks you want to trigger on arrow button click events. Will receive the current frame index as an argument. | {} |
-| customStyles | object | An object whose keys match one or more style definition on the component's `defaultStyles` object. Styles on these keys will be used to overwrite or augment default styles. | {} |
-
-```
-## custom styles keys:
-{
-  slider,
-  container,
-  list,
-  slide,
-  dots,
-  dot,
-  activeDot,
-  arrowLeft,
-  arrowRight,
-  arrowsAfter
-}
-```
 
 ## Development
 ```

--- a/css/index.css
+++ b/css/index.css
@@ -1,4 +1,10 @@
 /* support for mobile via autoprefixer */
+.csfd-content-slider {
+  position: relative;
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .csfd-content-slider ul {
   display: flex;
 }
@@ -11,6 +17,83 @@
 
 .csfd-content-slider iframe {
   min-height: 250px;
+}
+
+.csfd-content-slider-container {
+  position: relative;
+  height: inherit;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.csfd-content-slider-list {
+  position: absolute;
+  display: flex;
+  height: auto;
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+.csfd-content-slider-slide {
+  position: relative;
+  width: 100%;
+  height: inherit;
+  box-sizing: border-box;
+}
+
+.csfd-content-slider-dots {
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  z-index: 100;
+}
+
+.csfd-content-slider-dot {
+  width: 15px;
+  height: 15px;
+  background-color: #999;
+  border: 0;
+  border-radius: 50%;
+  padding: 0;
+  margin: 0 8px;
+}
+
+.csfd-content-slider-dot.active {
+  width: 20px;
+  height: 20px;
+  background-color: #FFF;
+}
+
+.csfd-content-slider-arrow-left,
+.csfd-content-slider-arrow-right {
+  position: absolute;
+  top: calc(50% - 2em);
+  width: 6em;
+  height: 4em;
+  background-color: rgba(0, 0, 0, 0.5);
+  border: 0;
+  z-index: 100;
+}
+
+.csfd-content-slider-arrow-left {
+  left: 0;
+}
+
+.csfd-content-slider-arrow-right {
+  right: 0
+}
+
+.csfd-content-slider-arrow-left span,
+.csfd-content-slider-arrow-right span {
+  color: #FFF;
+  font-size: 18px;
 }
 
 /*

--- a/demo/index.css
+++ b/demo/index.css
@@ -25,6 +25,14 @@ h1 {
   margin-top: 40px;
 }
 
+.example-2 .csfd-content-slider-slide {
+  background-color: #EFEFEF;
+  border: 1px solid #CCC;
+  display: inline-block;
+  height: auto;
+  width: 400;
+}
+
 .news img {
   width: 100%;
   height: 220px;

--- a/demo/index.js
+++ b/demo/index.js
@@ -66,15 +66,6 @@ ReactDOM.render(
         isCircular={true}
         showDots={false}
         maxAspectRatio={1.5}
-        customStyles={{
-          slide: {
-            display: 'inline-block',
-            backgroundColor: '#efefef',
-            width: 400,
-            height: 'auto',
-            border: '1px solid #ccc'
-          }
-        }}
       >
         {
           news.map(({ headline, image, body }, idx) =>

--- a/demo/staging.html
+++ b/demo/staging.html
@@ -39,6 +39,14 @@
       margin-top: 40px;
     }
 
+    .example-2 .csfd-content-slider-slide {
+      background-color: #EFEFEF;
+      border: 1px solid #CCC;
+      display: inline-block;
+      height: auto;
+      width: 400;
+    }
+
     .news img {
       width: 100%;
       height: 220px;
@@ -134,15 +142,6 @@
             slideHalf={true}
             showDots={false}
             maxAspectRatio={1.5}
-            customStyles={{
-              slide: {
-                display: 'inline-block',
-                backgroundColor: '#efefef',
-                width: 400,
-                height: 'auto',
-                border: '1px solid #ccc'
-              }
-            }}
           >
             {
               news.map(({ headline, image, body }, idx) =>

--- a/package.json
+++ b/package.json
@@ -37,10 +37,6 @@
     "Team Crossfield"
   ],
   "license": "MIT",
-  "dependencies": {
-    "autoprefixer": "^6.7.7",
-    "postcss-js": "^0.3.0"
-  },
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "babel-core": "^6.22.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,11 +19,19 @@ describe('ContentSlider', () => {
   const SLIDER_DOTS_CLASS = '.csfd-content-slider-dots';
   const SLIDER_DOT_CLASS = '.csfd-content-slider-dot';
 
-  before(() => {
+  before((done) => {
+    const style = document.createElement('link');
+    style.rel = 'stylesheet';
+    style.type = 'text/css';
+    style.href = '../css/index.css';
+    document.head.appendChild(style);
+
     const targetEl = document.createElement('section');
     document.body.appendChild(targetEl);
     document.querySelector('section').id = 'target';
     mountTarget = document.querySelector('#target');
+
+    style.onload = () => done();
   });
 
   describe('initial render', () => {
@@ -122,11 +130,6 @@ describe('ContentSlider', () => {
 
       it('should not show nav dots if showDots false', () => {
         expect(wrapper.find(SLIDER_DOTS_CLASS)).to.have.length(0);
-      });
-
-      it('should merge any styles passed in by the user', () => {
-        const styleProps = wrapper.first(SLIDER_SLIDE_CLASS).node.styles;
-        expect(styleProps.slide.backgroundColor).to.equal(slideBGColor);
       });
 
       it('should show frame (n * container width) per given frameIndexOverride', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -97,11 +97,6 @@ describe('ContentSlider', () => {
             uniqueIdStr={uniqueIdStr}
             showArrows={false}
             showDots={false}
-            customStyles={{
-              slide: {
-                backgroundColor: slideBGColor
-              }
-            }}
             frameIndexOverride={1}
           >
             <div className="test-slide">


### PR DESCRIPTION
This is my attempt to fix #9.

It is a breaking change as it removes the `customStyles` property and moves everything to rely on CSS stylesheets, leaving the user in charge of loading it and prefixing it if needed.
The only styles left inline are the ones that are dynamically generated (`transition`, `transform`, `height`, `width`, `top`).

Tests were also updated. I couldn't find a nice way to load the stylesheet for the tests and had to hack it away. Any feedback here is especially appreciated.